### PR TITLE
Add Jest testing setup and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,15 @@ cd backend
 python test_backend.py
 ```
 
+### Testing the Frontend
+
+Run the Jest test suite for the React components:
+
+```bash
+cd frontend
+npm test
+```
+
 ### CORS Configuration
 
 The backend is configured to accept requests from `http://localhost:3000`. To change this, modify the CORS settings in `backend/main.py`:

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  collectCoverageFrom: ['src/components/**/*.{js,jsx}'],
+  coverageThreshold: {
+    './src/components/Question.js': { branches: 80, functions: 80, lines: 80 },
+    './src/components/ScoreDisplay.js': { branches: 80, functions: 80, lines: 80 }
+  }
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,10 +8,16 @@
     "react-scripts": "5.0.1",
     "axios": "^1.6.0"
   },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jest": "^29.6.4"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "jest --watch",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/src/components/tests/Question.test.js
+++ b/frontend/src/components/tests/Question.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Question from '../Question';
+
+const sampleQuestion = {
+  id: 1,
+  text: 'What is the capital of France?',
+  correct_answer: 'c',
+  options: [
+    { id: 'a', text: 'London' },
+    { id: 'b', text: 'Berlin' },
+    { id: 'c', text: 'Paris' }
+  ]
+};
+
+test('renders question text and choices', () => {
+  render(
+    <Question
+      question={sampleQuestion}
+      selectedAnswer={null}
+      onAnswerSelect={() => {}}
+      showFeedback={false}
+      disabled={false}
+    />
+  );
+
+  expect(screen.getByText('What is the capital of France?')).toBeInTheDocument();
+  expect(screen.getByText('London')).toBeInTheDocument();
+  expect(screen.getByText('Berlin')).toBeInTheDocument();
+  expect(screen.getByText('Paris')).toBeInTheDocument();
+});
+
+test('invokes callback when an answer is selected', () => {
+  const mockSelect = jest.fn();
+
+  render(
+    <Question
+      question={sampleQuestion}
+      selectedAnswer={null}
+      onAnswerSelect={mockSelect}
+      showFeedback={false}
+      disabled={false}
+    />
+  );
+
+  fireEvent.click(screen.getByText('Paris'));
+  expect(mockSelect).toHaveBeenCalledWith(1, 'c');
+});

--- a/frontend/src/components/tests/ScoreDisplay.test.js
+++ b/frontend/src/components/tests/ScoreDisplay.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScoreDisplay from '../ScoreDisplay';
+
+const mockResults = (score) => ({
+  correct_answers: score,
+  total_questions: 5,
+  score_percentage: (score / 5) * 100,
+  answers: []
+});
+
+const questions = [
+  { id: 1, text: 'Question 1', options: [{ id: 'a', text: 'A' }], correct_answer: 'a' }
+];
+
+test('displays the correct score based on props', () => {
+  const results = mockResults(3);
+  render(<ScoreDisplay results={results} questions={questions} onRestart={() => {}} />);
+  expect(screen.getByText('3/5')).toBeInTheDocument();
+  expect(screen.getByText(/60% Correct/)).toBeInTheDocument();
+});
+
+test('matches snapshot for different score values', () => {
+  const { asFragment } = render(
+    <ScoreDisplay results={mockResults(5)} questions={questions} onRestart={() => {}} />
+  );
+  expect(asFragment()).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library dev dependencies
- configure `jest` script and coverage thresholds
- create basic tests for `Question` and `ScoreDisplay` components
- document how to run the front-end test suite

## Testing
- `npm test -- --watchAll=false --coverage` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685711601b4883248394047682faea65