### PR TITLE
Fix quiz scoring for AI questions

### DIFF
--- a/backend/test_backend.py
+++ b/backend/test_backend.py
@@ -65,10 +65,10 @@ def test_quiz_logic():
     
     # Sample answers
     answers = [
-        {"question_id": 1, "selected_answer": "c"},  # Correct
-        {"question_id": 2, "selected_answer": "a"},  # Incorrect (correct is "b")
+        {"question_id": 1, "selected_answer": "c", "correct_answer": "c"},  # Correct
+        {"question_id": 2, "selected_answer": "a", "correct_answer": "b"},  # Incorrect
     ]
-    
+
     correct_answers_map = {1: "c", 2: "b"}
     
     correct_count = 0

--- a/frontend/src/components/Quiz.js
+++ b/frontend/src/components/Quiz.js
@@ -53,9 +53,11 @@ const Quiz = ({ onRestart, category, source }) => {
   const handleAnswerSubmit = () => {
     if (!selectedAnswer) return;
 
+    const currentQuestion = questions[currentQuestionIndex];
     const newAnswer = {
-      question_id: questions[currentQuestionIndex].id,
-      selected_answer: selectedAnswer
+      question_id: currentQuestion.id,
+      selected_answer: selectedAnswer,
+      correct_answer: currentQuestion.correct_answer,
     };
 
     setAnswers([...answers, newAnswer]);


### PR DESCRIPTION
## Summary
- allow QuizAnswer to include a `correct_answer`
- update quiz submission logic to use provided answers if a DB record is missing
- include the correct answer when submitting from the frontend
- adjust backend unit test for new answer format

## Testing
- `python test_backend.py`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586e0491f48324a87e44789966f9e1