### PR TITLE
Allow custom quiz topics

### DIFF
--- a/frontend/src/components/SubjectSelection.js
+++ b/frontend/src/components/SubjectSelection.js
@@ -6,6 +6,7 @@ const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:800
 const SubjectSelection = ({ onSelectionComplete }) => {
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('');
+  const [customCategory, setCustomCategory] = useState('');
   const [questionSource, setQuestionSource] = useState('database'); // 'database' or 'ai'
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -27,13 +28,15 @@ const SubjectSelection = ({ onSelectionComplete }) => {
   };
 
   const handleStartQuiz = () => {
-    if (!selectedCategory) {
-      setError('Please select a subject to continue.');
+    const finalCategory = questionSource === 'ai' ? customCategory || selectedCategory : selectedCategory;
+
+    if (!finalCategory) {
+      setError('Please select or enter a subject to continue.');
       return;
     }
 
     onSelectionComplete({
-      category: selectedCategory,
+      category: finalCategory,
       source: questionSource
     });
   };
@@ -63,22 +66,38 @@ const SubjectSelection = ({ onSelectionComplete }) => {
       <p>Choose a subject and question source to start your personalized quiz!</p>
 
       <div className="subject-selection">
-        <div className="form-group">
-          <label htmlFor="category-select">Subject:</label>
-          <select
-            id="category-select"
-            value={selectedCategory}
-            onChange={(e) => setSelectedCategory(e.target.value)}
-            className="category-select"
-          >
-            <option value="">Choose a subject...</option>
-            {categories.map((category) => (
-              <option key={category} value={category}>
-                {category.charAt(0).toUpperCase() + category.slice(1)}
-              </option>
-            ))}
-          </select>
-        </div>
+        {questionSource === 'database' && (
+          <div className="form-group">
+            <label htmlFor="category-select">Subject:</label>
+            <select
+              id="category-select"
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="category-select"
+            >
+              <option value="">Choose a subject...</option>
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category.charAt(0).toUpperCase() + category.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {questionSource === 'ai' && (
+          <div className="form-group">
+            <label htmlFor="custom-subject">Subject:</label>
+            <input
+              id="custom-subject"
+              type="text"
+              className="category-select"
+              placeholder="Type any subject..."
+              value={customCategory}
+              onChange={(e) => setCustomCategory(e.target.value)}
+            />
+          </div>
+        )}
 
         <div className="form-group">
           <label>Question Source:</label>
@@ -112,10 +131,10 @@ const SubjectSelection = ({ onSelectionComplete }) => {
           </div>
         </div>
 
-        <button 
+        <button
           className="button"
           onClick={handleStartQuiz}
-          disabled={!selectedCategory}
+          disabled={!(questionSource === 'ai' ? (customCategory || selectedCategory) : selectedCategory)}
         >
           Start Quiz
         </button>

--- a/frontend/src/components/__tests__/SubjectSelection.test.js
+++ b/frontend/src/components/__tests__/SubjectSelection.test.js
@@ -61,13 +61,13 @@ describe('SubjectSelection Component', () => {
       expect(screen.getByText('Geography')).toBeInTheDocument();
     });
 
-    // Select a category
-    const categorySelect = screen.getByLabelText('Subject:');
-    fireEvent.change(categorySelect, { target: { value: 'geography' } });
-
-    // Select AI questions
+    // Switch to AI questions
     const aiRadio = screen.getByDisplayValue('ai');
     fireEvent.click(aiRadio);
+
+    // Enter custom subject
+    const customInput = screen.getByPlaceholderText('Type any subject...');
+    fireEvent.change(customInput, { target: { value: 'history' } });
 
     // Click start quiz button
     const startButton = screen.getByText('Start Quiz');
@@ -75,7 +75,7 @@ describe('SubjectSelection Component', () => {
 
     // Check that callback was called with correct parameters
     expect(mockOnSelectionComplete).toHaveBeenCalledWith({
-      category: 'geography',
+      category: 'history',
       source: 'ai'
     });
   });


### PR DESCRIPTION
## Summary
- allow text input for arbitrary quiz subjects when using AI questions
- keep dropdown for database categories
- update tests for new UI

## Testing
- `python backend/test_backend.py`
- `python backend/test_ai_integration.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae8dd81b08324b10f39ead90e07d8