### PR TITLE
Feat: Allow user-defined quiz topics for AI questions

### DIFF
--- a/frontend/src/components/SubjectSelection.js
+++ b/frontend/src/components/SubjectSelection.js
@@ -6,6 +6,7 @@ const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:800
 const SubjectSelection = ({ onSelectionComplete }) => {
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('');
+  const [customCategory, setCustomCategory] = useState('');
   const [questionSource, setQuestionSource] = useState('database'); // 'database' or 'ai'
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -27,13 +28,16 @@ const SubjectSelection = ({ onSelectionComplete }) => {
   };
 
   const handleStartQuiz = () => {
-    if (!selectedCategory) {
-      setError('Please select a subject to continue.');
+    const categoryToUse = questionSource === 'ai' ? customCategory : selectedCategory;
+
+    if (!categoryToUse) {
+      setError('Please select or enter a subject to continue.');
       return;
     }
+    setError(null); // Clear any previous error
 
     onSelectionComplete({
-      category: selectedCategory,
+      category: categoryToUse,
       source: questionSource
     });
   };
@@ -63,22 +67,39 @@ const SubjectSelection = ({ onSelectionComplete }) => {
       <p>Choose a subject and question source to start your personalized quiz!</p>
 
       <div className="subject-selection">
-        <div className="form-group">
-          <label htmlFor="category-select">Subject:</label>
-          <select
-            id="category-select"
-            value={selectedCategory}
-            onChange={(e) => setSelectedCategory(e.target.value)}
-            className="category-select"
-          >
-            <option value="">Choose a subject...</option>
-            {categories.map((category) => (
-              <option key={category} value={category}>
-                {category.charAt(0).toUpperCase() + category.slice(1)}
-              </option>
-            ))}
-          </select>
-        </div>
+        {questionSource === 'database' && (
+          <div className="form-group">
+            <label htmlFor="category-select">Subject (Curated):</label>
+            <select
+              id="category-select"
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="category-select"
+            >
+              <option value="">Choose a subject...</option>
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category.charAt(0).toUpperCase() + category.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {questionSource === 'ai' && (
+          <div className="form-group">
+            <label htmlFor="custom-category-input">Subject (AI):</label>
+            <input
+              type="text"
+              id="custom-category-input"
+              value={customCategory}
+              onChange={(e) => setCustomCategory(e.target.value)}
+              placeholder="Enter any topic (e.g., 'Roman History')"
+              className="category-input"
+            />
+            <small>Enter a topic for AI-generated questions.</small>
+          </div>
+        )}
 
         <div className="form-group">
           <label>Question Source:</label>
@@ -112,10 +133,13 @@ const SubjectSelection = ({ onSelectionComplete }) => {
           </div>
         </div>
 
-        <button 
+        <button
           className="button"
           onClick={handleStartQuiz}
-          disabled={!selectedCategory}
+          disabled={
+            (questionSource === 'database' && !selectedCategory) ||
+            (questionSource === 'ai' && !customCategory)
+          }
         >
           Start Quiz
         </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -253,7 +253,18 @@ body {
   transition: border-color 0.3s ease;
 }
 
-.category-select:focus {
+.category-input { /* Added for the text input */
+  width: 100%;
+  padding: 12px;
+  border: 2px solid #e1e5e9;
+  border-radius: 8px;
+  font-size: 16px;
+  background: white;
+  transition: border-color 0.3s ease;
+}
+
+.category-select:focus,
+.category-input:focus { /* Added focus for text input */
   outline: none;
   border-color: #667eea;
   box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
@@ -300,4 +311,13 @@ body {
 .radio-label input[type="radio"]:checked + .radio-text {
   color: #667eea;
   font-weight: 600;
+}
+
+/* Styling for the small helper text under the custom category input */
+.form-group small {
+  display: block;
+  font-size: 0.85em;
+  color: #666;
+  margin-top: 6px; /* Increased margin-top slightly */
+  padding-left: 2px; /* Align with input text if needed */
 }


### PR DESCRIPTION
Users can now type in a custom topic when selecting AI-generated questions, providing greater flexibility beyond predefined categories.

- Modified SubjectSelection.js to include a text input for custom topics when the 'ai' question source is selected.
- The existing dropdown for categories is retained for 'database' (curated) questions.
- Updated button disabled logic to account for custom topic input.
- Added CSS for the new input field to maintain visual consistency.