### PR TITLE
Add logging configuration panel

### DIFF
--- a/backend/logging_config_manager.py
+++ b/backend/logging_config_manager.py
@@ -1,0 +1,81 @@
+import json
+import os
+import logging
+from logging.handlers import RotatingFileHandler
+
+DEFAULT_CONFIG = {
+    "backend": {
+        "level": "INFO",
+        "max_bytes": 1048576,
+        "backup_count": 3
+    }
+}
+
+class LoggingConfigManager:
+    def __init__(self, config_file: str = "logging_config.json"):
+        self.config_file = config_file
+        self.config = self._load_config()
+        self._ensure_log_dirs()
+        self._handler: RotatingFileHandler | None = None
+        self.apply_config()
+
+    def _load_config(self):
+        if os.path.exists(self.config_file):
+            try:
+                with open(self.config_file, "r") as f:
+                    return json.load(f)
+            except Exception:
+                pass
+        return DEFAULT_CONFIG.copy()
+
+    def _ensure_log_dirs(self):
+        os.makedirs(os.path.join("logs", "backend"), exist_ok=True)
+
+    def save_config(self):
+        with open(self.config_file, "w") as f:
+            json.dump(self.config, f, indent=2)
+
+    def get_config(self):
+        return self.config.copy()
+
+    def apply_config(self):
+        level_name = self.config.get("backend", {}).get("level", "INFO").upper()
+        level = getattr(logging, level_name, logging.INFO)
+        root_logger = logging.getLogger()
+        root_logger.setLevel(level)
+
+        log_path = os.path.join("logs", "backend", "api.log")
+        if not self._handler:
+            self._handler = RotatingFileHandler(
+                log_path,
+                maxBytes=self.config["backend"].get("max_bytes", 1048576),
+                backupCount=self.config["backend"].get("backup_count", 3),
+            )
+            formatter = logging.Formatter(
+                "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+            )
+            self._handler.setFormatter(formatter)
+            root_logger.addHandler(self._handler)
+        else:
+            self._handler.maxBytes = self.config["backend"].get("max_bytes", 1048576)
+            self._handler.backupCount = self.config["backend"].get("backup_count", 3)
+
+    def update_config(self, updates: dict):
+        if "backend" in updates:
+            self.config["backend"].update(updates["backend"])
+        self.save_config()
+        self.apply_config()
+        return self.get_config()
+
+    def get_recent_logs(self, lines: int = 100):
+        log_path = os.path.join("logs", "backend", "api.log")
+        if not os.path.exists(log_path):
+            return []
+        with open(log_path, "r") as f:
+            return f.readlines()[-lines:]
+
+    def clear_logs(self):
+        log_path = os.path.join("logs", "backend", "api.log")
+        open(log_path, "w").close()
+
+logging_config_manager = LoggingConfigManager()

--- a/frontend/src/components/AdminPanel.js
+++ b/frontend/src/components/AdminPanel.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import AdminQuestions from './AdminQuestions';
 import LLMSettings from './LLMSettings';
+import LoggingSettings from './LoggingSettings';
 
 const AdminPanel = ({ onGoHome }) => {
   const [activeTab, setActiveTab] = useState('questions');
@@ -9,7 +10,7 @@ const AdminPanel = ({ onGoHome }) => {
     <div className="admin-container">
       <div className="admin-header">
         <h1>🛠️ Admin Panel</h1>
-        <p>Manage quiz questions and LLM settings</p>
+        <p>Manage quiz questions, LLM settings and logging</p>
         <button className="button" onClick={onGoHome}>
           Back to Home
         </button>
@@ -22,11 +23,17 @@ const AdminPanel = ({ onGoHome }) => {
         >
           📝 Questions
         </button>
-        <button 
+        <button
           className={`tab-button ${activeTab === 'llm' ? 'active' : ''}`}
           onClick={() => setActiveTab('llm')}
         >
           🤖 LLM Settings
+        </button>
+        <button
+          className={`tab-button ${activeTab === 'logging' ? 'active' : ''}`}
+          onClick={() => setActiveTab('logging')}
+        >
+          📜 Logging
         </button>
       </div>
 
@@ -36,6 +43,9 @@ const AdminPanel = ({ onGoHome }) => {
         )}
         {activeTab === 'llm' && (
           <LLMSettings />
+        )}
+        {activeTab === 'logging' && (
+          <LoggingSettings />
         )}
       </div>
     </div>

--- a/frontend/src/components/LoggingSettings.js
+++ b/frontend/src/components/LoggingSettings.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000';
+const LEVELS = ['ERROR', 'WARNING', 'INFO', 'DEBUG'];
+
+const LoggingSettings = () => {
+  const [config, setConfig] = useState(null);
+  const [logs, setLogs] = useState([]);
+  const [saving, setSaving] = useState(false);
+
+  const fetchConfig = async () => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/api/logging/config`);
+      setConfig(res.data.backend ? res.data : { backend: { level: res.data.level } });
+    } catch (err) {
+      console.error('Failed to fetch logging config', err);
+    }
+  };
+
+  const fetchLogs = async () => {
+    try {
+      const res = await axios.get(`${API_BASE_URL}/api/logging/logs?lines=100`);
+      setLogs(res.data.logs || []);
+    } catch (err) {
+      console.error('Failed to fetch logs', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchConfig();
+    fetchLogs();
+  }, []);
+
+  const handleLevelChange = (e) => {
+    setConfig(prev => ({ ...prev, backend: { ...prev.backend, level: e.target.value } }));
+  };
+
+  const saveConfig = async () => {
+    try {
+      setSaving(true);
+      await axios.put(`${API_BASE_URL}/api/logging/config`, { backend: { level: config.backend.level } });
+      fetchConfig();
+    } catch (err) {
+      console.error('Failed to save logging config', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="logging-settings">
+      <h3>🔍 Logging Configuration</h3>
+      {config && (
+        <div className="form-group">
+          <label>Backend Log Level:</label>
+          <select value={config.backend.level} onChange={handleLevelChange} className="form-select">
+            {LEVELS.map(l => <option key={l} value={l}>{l}</option>)}
+          </select>
+          <button className="button" onClick={saveConfig} disabled={saving}>{saving ? 'Saving...' : 'Save'}</button>
+        </div>
+      )}
+      <div className="log-viewer">
+        <h4>Recent Logs</h4>
+        <pre className="log-output">
+{logs.join('')}
+        </pre>
+        <button className="button" onClick={fetchLogs}>Refresh</button>
+      </div>
+    </div>
+  );
+};
+
+export default LoggingSettings;


### PR DESCRIPTION
## Summary
- support persistent logging config on the backend
- expose logging endpoints for runtime log level control
- add minimal log viewer in the admin panel
- include new Logging tab in the admin UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697a33ad248324b9561f44d8ec5760