### PR TITLE
Override glob to avoid inflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ An interactive web-based quiz application that allows users to test their knowle
    ```bash
    npm install
    ```
+   The project overrides `glob` to the latest version to avoid the deprecated
+   `inflight` package warning.
 
 3. **Start the React development server:**
    ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,5 +44,8 @@
     "babel-jest": "^29.7.0",
     "identity-obj-proxy": "^3.0.0",
     "jest-environment-jsdom": "^29.7.0"
+  },
+  "overrides": {
+    "glob": "^10.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4"
+  },
+  "overrides": {
+    "glob": "^10.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- avoid `inflight` by overriding `glob` to v10 in both Node projects
- mention the override in the setup docs

## Testing
- `./run_tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_686ad6463e4c83248eaf13972e6e874a