### PR TITLE
Fix w3c-hr-time deprecation warning

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "jest-environment-jsdom": "^29.7.0"
   },
   "overrides": {
-    "glob": "^10.4.5"
+    "glob": "^10.4.5",
+    "jsdom": "^20.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- override jsdom dependency with a modern version

## Testing
- `./run_tests.sh` *(fails: npm install requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686ade0bf73c8324a815ff010fa45d6f