### PR TITLE
Remove deprecated stable dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12079,7 +12079,7 @@
       "integrity": "sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==",
       "license": "MIT",
       "dependencies": {
-        "picocolors": "^1.0.0",
+"picocolors": "^1.0.0"
         "shell-quote": "^1.8.1"
       }
     },
@@ -14477,8 +14477,7 @@
         "css-select": "^4.1.3",
         "css-tree": "^1.1.3",
         "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
+        "picocolors": "^1.0.0"
       },
       "bin": {
         "svgo": "bin/svgo"
@@ -16187,13 +16186,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "license": "MIT"
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -16777,7 +16769,6 @@
         "mkdirp": "~0.5.1",
         "object.values": "^1.1.0",
         "sax": "~1.2.4",
-        "stable": "^0.1.8",
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
   },
   "overrides": {
     "glob": "^10.4.5",
-    "jsdom": "^20.0.3"
+    "jsdom": "^20.0.3",
+    "stable": "file:../overrides/stable"
   }
 }

--- a/overrides/stable/index.js
+++ b/overrides/stable/index.js
@@ -1,0 +1,6 @@
+module.exports = function stable(arr, compare) {
+  if (compare) {
+    return arr.sort(compare);
+  }
+  return arr.sort();
+};

--- a/overrides/stable/package.json
+++ b/overrides/stable/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "stable",
+  "version": "0.1.8",
+  "description": "Local replacement for deprecated stable package",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "jest-environment-jsdom": "^30.0.4"
   },
   "overrides": {
-    "glob": "^10.4.5"
+    "glob": "^10.4.5",
+    "stable": "file:./overrides/stable"
   }
 }


### PR DESCRIPTION
## Summary
- provide local stub for the deprecated `stable` package
- ensure root and frontend force using the stub
- clean up `package-lock.json` to remove `stable`

## Testing
- `./run_tests.sh` *(fails: npm install requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686ae4a8cef8832488e82fc07fccf98b