### PR TITLE
Fix deprecated sourcemap-codec warning

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11553,7 +11553,7 @@
       "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/make-dir": {
@@ -15347,13 +15347,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "license": "MIT"
     },
     "node_modules/spdy": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
   "overrides": {
     "glob": "^10.4.5",
     "jsdom": "^20.0.3",
-    "svgo": "^3.3.2"
+    "svgo": "^3.3.2",
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "jest-environment-jsdom": "^30.0.4"
   },
   "overrides": {
-    "glob": "^10.4.5"
+    "glob": "^10.4.5",
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- map sourcemap-codec to @jridgewell/sourcemap-codec in root and frontend package.json
- update frontend package-lock to remove deprecated sourcemap-codec

## Testing
- `bash run_tests.sh` *(fails: Failed to download GitLeaks; Installing frontend dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ae94691dc8324b645afff07a9b92d