### PR TITLE
Convert log level dropdown to slider

### DIFF
--- a/frontend/src/components/LoggingSettings.js
+++ b/frontend/src/components/LoggingSettings.js
@@ -14,6 +14,10 @@ const LoggingSettings = () => {
   const [activeTab, setActiveTab] = useState('levels');
   const [logFilter, setLogFilter] = useState('all');
 
+  const LOG_LEVELS = ['ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'];
+  const levelToPosition = (level) => LOG_LEVELS.indexOf(level);
+  const positionToLevel = (pos) => LOG_LEVELS[pos] || 'INFO';
+
   useEffect(() => {
     fetchConfig();
     fetchLogFiles();
@@ -190,17 +194,33 @@ const LoggingSettings = () => {
             {editConfig?.log_levels?.frontend && Object.entries(editConfig.log_levels.frontend).map(([component, level]) => (
               <div key={component} className="log-level-control">
                 <label>Frontend {component}:</label>
-                <select
-                  value={level}
-                  onChange={(e) => handleLogLevelChange('frontend', component, e.target.value)}
-                  className="form-select"
-                >
-                  <option value="ERROR">ERROR</option>
-                  <option value="WARN">WARN</option>
-                  <option value="INFO">INFO</option>
-                  <option value="DEBUG">DEBUG</option>
-                  <option value="TRACE">TRACE</option>
-                </select>
+                <div className="log-slider">
+                  <input
+                    type="range"
+                    min="0"
+                    max="4"
+                    step="1"
+                    value={levelToPosition(level)}
+                    onChange={(e) =>
+                      handleLogLevelChange(
+                        'frontend',
+                        component,
+                        positionToLevel(Number(e.target.value))
+                      )
+                    }
+                    aria-label={`Set log level for frontend ${component}`}
+                  />
+                  <div className="slider-labels">
+                    {LOG_LEVELS.map((lvl, idx) => (
+                      <span
+                        key={lvl}
+                        className={idx === levelToPosition(level) ? 'active' : ''}
+                      >
+                        {lvl}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               </div>
             ))}
           </div>
@@ -210,17 +230,33 @@ const LoggingSettings = () => {
             {editConfig?.log_levels?.backend && Object.entries(editConfig.log_levels.backend).map(([component, level]) => (
               <div key={component} className="log-level-control">
                 <label>Backend {component}:</label>
-                <select
-                  value={level}
-                  onChange={(e) => handleLogLevelChange('backend', component, e.target.value)}
-                  className="form-select"
-                >
-                  <option value="ERROR">ERROR</option>
-                  <option value="WARN">WARN</option>
-                  <option value="INFO">INFO</option>
-                  <option value="DEBUG">DEBUG</option>
-                  <option value="TRACE">TRACE</option>
-                </select>
+                <div className="log-slider">
+                  <input
+                    type="range"
+                    min="0"
+                    max="4"
+                    step="1"
+                    value={levelToPosition(level)}
+                    onChange={(e) =>
+                      handleLogLevelChange(
+                        'backend',
+                        component,
+                        positionToLevel(Number(e.target.value))
+                      )
+                    }
+                    aria-label={`Set log level for backend ${component}`}
+                  />
+                  <div className="slider-labels">
+                    {LOG_LEVELS.map((lvl, idx) => (
+                      <span
+                        key={lvl}
+                        className={idx === levelToPosition(level) ? 'active' : ''}
+                      >
+                        {lvl}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               </div>
             ))}
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1005,6 +1005,53 @@ body {
   width: 120px;
 }
 
+.log-level-control .log-slider {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.log-slider input[type='range'] {
+  width: 100%;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  border-radius: 5px;
+  background: #e1e5e9;
+  outline: none;
+}
+
+.log-slider input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #667eea;
+  cursor: pointer;
+}
+
+.log-slider input[type='range']::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #667eea;
+  cursor: pointer;
+}
+
+.slider-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  margin-top: 4px;
+  user-select: none;
+}
+
+.slider-labels span.active {
+  font-weight: bold;
+  color: #667eea;
+}
+
 .log-files-section {
   background: #f9f9f9;
   padding: 20px;


### PR DESCRIPTION
## Summary
- add log level slider mapping helper methods
- replace select elements with range sliders for frontend/backened log levels
- style new slider component

## Testing
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'fastapi', npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686aef996d3c8324904d7a9892a1fdf8