### PR TITLE
Fix webpack-dev-server version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14192,7 +14192,7 @@
         "tailwindcss": "^3.0.2",
         "terser-webpack-plugin": "^5.2.5",
         "webpack": "^5.64.4",
-        "webpack-dev-server": "^4.6.0",
+        "webpack-dev-server": "5.2.1",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       },
@@ -16853,9 +16853,8 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-      "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.1.tgz",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "glob": "^10.4.5",
     "jsdom": "^20.0.3",
     "svgo": "^3.3.2",
-    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0",
+    "webpack-dev-server": "5.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "overrides": {
     "glob": "^10.4.5",
-    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0",
+    "webpack-dev-server": "5.2.1"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary
- override `webpack-dev-server` with version 5.2.1 to address origin validation CVE

## Testing
- `bash run_tests.sh` *(fails: 403 Forbidden when installing jest)*

------
https://chatgpt.com/codex/tasks/task_e_686d0c486cb88324860c0c99fa29dab4