### PR TITLE
Fix path traversal in log download endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ import json
 import uuid
 from datetime import datetime
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -82,6 +83,15 @@ def setup_logging():
 # Setup logging
 setup_logging()
 logger = logging.getLogger(__name__)
+
+
+def secure_log_path(file_path: str) -> str:
+    """Return an absolute path within the configured logs directory."""
+    base_dir = Path(logging_config_manager.logs_dir).resolve()
+    requested_path = (base_dir / file_path).resolve()
+    if not str(requested_path).startswith(str(base_dir)):
+        raise HTTPException(status_code=400, detail="Invalid file path")
+    return str(requested_path)
 
 app = FastAPI(title="Quizly API", description="Knowledge Testing Application API")
 
@@ -722,9 +732,8 @@ def download_log_file(file_path: str):
     """Download a specific log file"""
     try:
         from fastapi.responses import FileResponse
-        import os
         
-        full_path = os.path.join(logging_config_manager.logs_dir, file_path)
+        full_path = secure_log_path(file_path)
         if not os.path.exists(full_path):
             raise HTTPException(status_code=404, detail="Log file not found")
         

--- a/tests/backend/unit/test_path_traversal.py
+++ b/tests/backend/unit/test_path_traversal.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# Add backend to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', 'backend'))
+from main import app
+
+client = TestClient(app)
+
+def test_download_log_file_path_traversal():
+    response = client.get('/api/logging/files/../secret.txt/download')
+    assert response.status_code == 400
+


### PR DESCRIPTION
## Summary
- validate log file paths before download
- test path traversal protection

## Testing
- `./run_tests.sh` *(fails: npm E403 fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68729f9a335c832490a3ca47f40c4b27